### PR TITLE
Load/Save bad location error handling

### DIFF
--- a/tests/hnswgo_test.go
+++ b/tests/hnswgo_test.go
@@ -615,6 +615,18 @@ func TestLoadIndexInvalidPath(t *testing.T) {
 	}
 }
 
+func TestLoadIndexEmptyPath(t *testing.T) {
+	index, err := hnswgo.LoadIndex("", 2, "l2", uint32(10000))
+	if index != nil {
+		defer index.Free()
+	}
+	if err == nil {
+		t.Fatal("No error occured when trying to load an index with a fake location.")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("Unexpected error received: %s", err.Error())
+	}
+}
+
 func TestLoadIndexInvalidPerms(t *testing.T) {
 	index, err := hnswgo.LoadIndex("/root/index.bin", 2, "l2", uint32(10000))
 	if index != nil {

--- a/tests/hnswgo_test.go
+++ b/tests/hnswgo_test.go
@@ -560,7 +560,7 @@ func TestSaveToDiskInvalidPerms(t *testing.T) {
 		}
 	}
 
-	if err := index.SaveToDisk("/tmp/perm_test/index.bin"); err == nil {
+	if err := index.SaveToDisk("/root/index.bin"); err == nil {
 		t.Fatal("No error occured when setting the location to a path with elevated permissions")
 	} else if !os.IsPermission(err) {
 		t.Fatalf("Unexpected error received: %s", err.Error())


### PR DESCRIPTION
Handling errors where the location passed into LoadIndex or SaveToDisk is invalid or requires additional permissions. 